### PR TITLE
Update DigitalOcean repository URL

### DIFF
--- a/.digitalocean/comet-starter-cms.tpl.yaml
+++ b/.digitalocean/comet-starter-cms.tpl.yaml
@@ -164,7 +164,7 @@ services:
     github:
       branch: main
       deploy_on_push: false
-      repo: vivid-planet/comet-starter
+      repo: vivid-planet/dextinity-starter
     http_port: 4000
     instance_count: 1
     instance_size_slug: apps-s-1vcpu-0.5gb
@@ -292,7 +292,7 @@ services:
     github:
       branch: main
       deploy_on_push: false
-      repo: vivid-planet/comet-starter
+      repo: vivid-planet/dextinity-starter
     http_port: 3000
     instance_count: 1
     instance_size_slug: apps-s-1vcpu-0.5gb

--- a/.digitalocean/comet-starter-site-main.tpl.yaml
+++ b/.digitalocean/comet-starter-site-main.tpl.yaml
@@ -57,7 +57,7 @@ services:
     github:
       branch: main
       deploy_on_push: false
-      repo: vivid-planet/comet-starter
+      repo: vivid-planet/dextinity-starter
     http_port: 3000
     instance_count: 1
     instance_size_slug: apps-s-1vcpu-0.5gb


### PR DESCRIPTION
The DigitalOcean deployment still used the old repository URL (comet-starter). Update to the new one (dextinity-starter).