### PR TITLE
Exclude `@dextinity/*` from `min-release-age`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 strict-peer-deps=true
 min-release-age=3
+min-release-age-exclude[]=@dextinity/*


### PR DESCRIPTION
## Problem

The root `.npmrc` sets `min-release-age=3`, so npm refuses to install any version published less than three days ago. That cooldown is a supply-chain safeguard aimed at third-party dependencies, but it applies to `@dextinity/*` as well — a freshly released Dextinity version cannot be installed or updated for three days.

## Solution

`min-release-age-exclude[]=@dextinity/*` exempts our own packages from the cooldown. Third-party dependencies keep the three-day delay.

## Decisions

- **Starter-only — not ported to the `dextinity` repo or its `demo/`.** That repo is a pnpm workspace and has no `.npmrc`, so there is no npm-side `min-release-age` cooldown to exempt `@dextinity/*` from; its own packages are workspace-linked in any case.
- The Renovate-side counterpart — `minimumReleaseAge` from the shared `renovate/default` preset — is a separate mechanism and is handled in [its own PR](https://github.com/vivid-planet/dextinity-starter/pull/1672).

## Further information

- Task: https://vivid-planet.atlassian.net/browse/DEX-3161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4aXwsvMLGJFpCjhUou4W7
