### PR TITLE
Exempt `@dextinity/*` from Renovate's `minimumReleaseAge`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,8 @@
             "prPriority": 6,
             "matchPackageNames": ["/@dextinity/*/"],
             "labels": ["dextinity", "dependencies"],
-            "allowedVersions": "!/canary/"
+            "allowedVersions": "!/canary/",
+            "minimumReleaseAge": null
         }
     ]
 }


### PR DESCRIPTION
## Problem

The shared `renovate/default` preset sets `"minimumReleaseAge": "3 days"` globally, so Renovate holds every update back for three days after publication — `@dextinity/*` included. Dextinity releases are our own, and waiting three days before Renovate even opens the PR delays picking them up for no benefit.

## Solution

`"minimumReleaseAge": null` on the existing `dextinity` package rule removes the cooldown for those packages, so Renovate opens the PR as soon as a version is published. Every other dependency keeps the three-day delay from the preset.

## Further information

- Task: https://vivid-planet.atlassian.net/browse/DEX-3161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4aXwsvMLGJFpCjhUou4W7
