### PR TITLE
Add Organization schema.org JSON-LD markup

### DIFF
--- a/site-configs/main.ts
+++ b/site-configs/main.ts
@@ -26,6 +26,13 @@ export default ((env) => {
                 languages: ["en", "de"],
             },
             gtmId: "GTM-XXXX",
+            organization: {
+                name: "Vivid Planet Software GmbH",
+                url: "https://www.vivid-planet.com",
+                logo: "/assets/dextinity-logo.svg",
+                sameAs: ["https://github.com/vivid-planet"],
+                description: "Vivid Planet Software GmbH develops Dextinity CMS, the open-source content management system.",
+            },
         },
     };
 }) satisfies GetSiteConfig;

--- a/site-configs/secondary.ts
+++ b/site-configs/secondary.ts
@@ -25,6 +25,9 @@ export default ((env) => {
                 languages: ["en", "de"],
             },
             gtmId: "GTM-YYYY",
+            organization: {
+                name: "Starter Secondary",
+            },
         },
     };
 }) satisfies GetSiteConfig;

--- a/site-configs/site-configs.d.ts
+++ b/site-configs/site-configs.d.ts
@@ -13,6 +13,13 @@ export interface SiteConfig extends BaseSiteConfig {
             languages: string[];
         };
         gtmId?: string;
+        organization: {
+            name: string;
+            url?: string;
+            logo?: string;
+            sameAs?: string[];
+            description?: string;
+        };
     };
 }
 

--- a/site/src/app/[visibility]/[domain]/[language]/layout.tsx
+++ b/site/src/app/[visibility]/[domain]/[language]/layout.tsx
@@ -3,6 +3,7 @@ import { Footer } from "@src/layout/footer/Footer";
 import { footerFragment } from "@src/layout/footer/Footer.fragment";
 import { Header } from "@src/layout/header/Header";
 import { headerFragment } from "@src/layout/header/Header.fragment";
+import { OrganizationJsonLd } from "@src/organization/OrganizationJsonLd";
 import { createGraphQLFetch } from "@src/util/graphQLClient";
 import { IntlProvider } from "@src/util/IntlProvider";
 import { loadMessages } from "@src/util/loadMessages";
@@ -67,6 +68,7 @@ export default async function Layout({ children, params }: LayoutProps<"/[visibi
                     </noscript>
                 )}
                 <IntlProvider locale={language} messages={messages}>
+                    <OrganizationJsonLd siteConfig={siteConfig} />
                     <Header header={header} />
                     {children}
                     {footer && <Footer footer={footer} />}

--- a/site/src/organization/OrganizationJsonLd.tsx
+++ b/site/src/organization/OrganizationJsonLd.tsx
@@ -1,0 +1,27 @@
+import { JsonLd } from "@dextinity/site-nextjs";
+import type { PublicSiteConfig } from "@src/site-configs";
+import type { Organization, WithContext } from "schema-dts";
+
+interface Props {
+    siteConfig: PublicSiteConfig;
+}
+
+function toAbsoluteUrl(url: string, siteUrl: string): string {
+    return new URL(url, siteUrl).toString();
+}
+
+export function OrganizationJsonLd({ siteConfig }: Props) {
+    const { organization, url: siteUrl } = siteConfig;
+
+    const data: WithContext<Organization> = {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        name: organization.name,
+        url: organization.url ?? siteUrl,
+        ...(organization.logo ? { logo: toAbsoluteUrl(organization.logo, siteUrl) } : {}),
+        ...(organization.sameAs?.length ? { sameAs: organization.sameAs } : {}),
+        ...(organization.description ? { description: organization.description } : {}),
+    };
+
+    return <JsonLd<Organization> data={data} />;
+}


### PR DESCRIPTION
Task: https://vivid-planet.atlassian.net/browse/DEX-2967 (parent epic: DEX-2963)
Ports vivid-planet/dextinity#6038 to the starter.

## Summary
Add structured data markup for organization information using schema.org's Organization type. This improves SEO and enables search engines to better understand the organization's identity and properties.

## Changes
- **New component**: `OrganizationJsonLd` - Renders Organization schema.org JSON-LD markup with support for name, URL, logo, social profiles, and description
- **Configuration**: Added `organization` field to site config with properties for name, URL, logo, social links (sameAs), and description
- **Integration**: Integrated `OrganizationJsonLd` component into the root layout to render organization metadata on all pages
- **Config updates**: Updated both main and secondary site configurations with organization details

## Implementation Details
- The component converts relative logo URLs to absolute URLs using the site's base URL
- Optional fields (logo, sameAs, description) are conditionally included in the JSON-LD output
- Uses the `@dextinity/site-nextjs` JsonLd component for rendering
- Follows schema.org Organization schema specification

https://claude.ai/code/session_017RmBZsgGhKXaLLzpGLwTDY