### PR TITLE
Rebrand DigitalOcean deployment to Dextinity

### DIFF
--- a/.digitalocean/.gitignore
+++ b/.digitalocean/.gitignore
@@ -1,2 +1,2 @@
-comet-starter-cms.yaml
-comet-starter-site-main.yaml
+dextinity-starter-cms.yaml
+dextinity-starter-site-main.yaml

--- a/.digitalocean/deploy.sh
+++ b/.digitalocean/deploy.sh
@@ -2,14 +2,14 @@
 
 # TODO move me to project root and change app ids if in use
 
-doctl apps update <imgproxy-app-id> --spec .digitalocean/comet-starter-imgproxy.yaml
+doctl apps update <imgproxy-app-id> --spec .digitalocean/dextinity-starter-imgproxy.yaml
 
-sed -i '' 's/dev\.comet\-dxp\.com/digitalocean.comet-dxp.com/g' site-configs/main.ts
+sed -i '' 's/dev\.dextinity\.com/digitalocean.dextinity.com/g' site-configs/main.ts
 
-APP_ENV=dev npx -y @dextinity/cli inject-site-configs -f site-configs/site-configs.ts -i .digitalocean/comet-starter-cms.tpl.yaml -o .digitalocean/comet-starter-cms.yaml --base64
-doctl apps update <cms-app-id> --spec .digitalocean/comet-starter-cms.yaml # configuration changes
+APP_ENV=dev npx -y @dextinity/cli inject-site-configs -f site-configs/site-configs.ts -i .digitalocean/dextinity-starter-cms.tpl.yaml -o .digitalocean/dextinity-starter-cms.yaml --base64
+doctl apps update <cms-app-id> --spec .digitalocean/dextinity-starter-cms.yaml # configuration changes
 doctl apps create-deployment xxxx # code changes
 
-APP_ENV=dev npx -y @dextinity/cli inject-site-configs -f site-configs/site-configs.ts -i .digitalocean/comet-starter-site-main.tpl.yaml -o .digitalocean/comet-starter-site-main.yaml --base64
-doctl apps update <site-main-app-id> --spec .digitalocean/comet-starter-site-main.yaml # configuration changes
+APP_ENV=dev npx -y @dextinity/cli inject-site-configs -f site-configs/site-configs.ts -i .digitalocean/dextinity-starter-site-main.tpl.yaml -o .digitalocean/dextinity-starter-site-main.yaml --base64
+doctl apps update <site-main-app-id> --spec .digitalocean/dextinity-starter-site-main.yaml # configuration changes
 doctl apps create-deployment yyyy # code changes

--- a/.digitalocean/dextinity-starter-cms.tpl.yaml
+++ b/.digitalocean/dextinity-starter-cms.tpl.yaml
@@ -2,7 +2,7 @@ alerts:
   - rule: DEPLOYMENT_FAILED
   - rule: DOMAIN_FAILED
 domains:
-  - domain: admin.digitalocean.comet-dxp.com
+  - domain: admin.digitalocean.dextinity.com
     type: PRIMARY
 features:
   - buildpack-stack=ubuntu-22
@@ -23,7 +23,7 @@ ingress:
       match:
         path:
           prefix: /public-api
-name: comet-starter-cms
+name: dextinity-starter-cms
 region: fra
 services:
   - build_command: |-
@@ -56,13 +56,13 @@ services:
         value: starter
       - key: API_URL
         scope: RUN_AND_BUILD_TIME
-        value: https://admin.digitalocean.comet-dxp.com/public-api/api
+        value: https://admin.digitalocean.dextinity.com/public-api/api
       - key: API_PORT
         scope: RUN_AND_BUILD_TIME
         value: "4000"
       - key: CORS_ALLOWED_ORIGIN
         scope: RUN_AND_BUILD_TIME
-        value: comet-starter-site-tyqqf\.ondigitalocean\.app
+        value: digitalocean\.dextinity\.com
       - key: IMGPROXY_SALT
         scope: RUN_AND_BUILD_TIME
         type: SECRET
@@ -92,7 +92,7 @@ services:
         value: https://fra1.digitaloceanspaces.com
       - key: S3_BUCKET
         scope: RUN_AND_BUILD_TIME
-        value: comet-starter
+        value: dextinity-starter
       - key: S3_ACCESS_KEY_ID
         scope: RUN_AND_BUILD_TIME
         type: SECRET
@@ -153,7 +153,7 @@ services:
         value: https://login.vivid-planet.cloud/oidc/v1/end_session
       - key: POST_LOGOUT_REDIRECT_URI
         scope: RUN_AND_BUILD_TIME
-        value: https://admin.digitalocean.comet-dxp.com/oauth2/sign_out?rd=%2F
+        value: https://admin.digitalocean.dextinity.com/oauth2/sign_out?rd=%2F
       - key: ACL_ALL_PERMISSIONS_DOMAINS
         scope: RUN_AND_BUILD_TIME
         value: "vivid-planet.com"
@@ -276,16 +276,16 @@ services:
         value: production
       - key: API_URL
         scope: RUN_AND_BUILD_TIME
-        value: https://admin.digitalocean.comet-dxp.com/api
+        value: https://admin.digitalocean.dextinity.com/api
       - key: ADMIN_URL
         scope: RUN_AND_BUILD_TIME
-        value: https://admin.digitalocean.comet-dxp.com/
+        value: https://admin.digitalocean.dextinity.com/
       - key: PUBLIC_SITE_CONFIGS
         scope: RUN_AND_BUILD_TIME
         value: "{{ site://configs/public/dev }}"
       - key: PREVIEW_URL
         scope: RUN_AND_BUILD_TIME
-        value: https://preview.digitalocean.comet-dxp.com
+        value: https://preview.digitalocean.dextinity.com
       - key: SERVER_HOST
         scope: RUN_AND_BUILD_TIME
         value: "0.0.0.0"

--- a/.digitalocean/dextinity-starter-imgproxy.yaml
+++ b/.digitalocean/dextinity-starter-imgproxy.yaml
@@ -10,7 +10,7 @@ ingress:
       match:
         path:
           prefix: /
-name: comet-starter-imgproxy
+name: dextinity-starter-imgproxy
 region: fra
 services:
   - envs:
@@ -30,7 +30,7 @@ services:
         value: fra1
       - key: IMGPROXY_S3_ENDPOINT
         scope: RUN_AND_BUILD_TIME
-        value: https://comet-starter.fra1.digitaloceanspaces.com
+        value: https://dextinity-starter.fra1.digitaloceanspaces.com
       - key: AWS_ACCESS_KEY_ID
         scope: RUN_AND_BUILD_TIME
         type: SECRET

--- a/.digitalocean/dextinity-starter-site-main.tpl.yaml
+++ b/.digitalocean/dextinity-starter-site-main.tpl.yaml
@@ -2,20 +2,20 @@ alerts:
   - rule: DEPLOYMENT_FAILED
   - rule: DOMAIN_FAILED
 domains:
-  - domain: digitalocean.comet-dxp.com
+  - domain: digitalocean.dextinity.com
     type: PRIMARY
-  - domain: preview.digitalocean.comet-dxp.com
+  - domain: preview.digitalocean.dextinity.com
     type: ALIAS
 features:
   - buildpack-stack=ubuntu-22
 ingress:
   rules:
     - component:
-        name: comet-starter-site-main
+        name: dextinity-starter-site-main
       match:
         path:
           prefix: /
-name: comet-starter-site-main
+name: dextinity-starter-site-main
 region: fra
 services:
   - build_command: |-
@@ -36,13 +36,13 @@ services:
         value: "0.0.0.0"
       - key: ADMIN_URL
         scope: RUN_AND_BUILD_TIME
-        value: https://admin.digitalocean.comet-dxp.com/
+        value: https://admin.digitalocean.dextinity.com/
       - key: NEXT_PUBLIC_API_URL
         scope: RUN_AND_BUILD_TIME
-        value: https://admin.digitalocean.comet-dxp.com/public-api/api
+        value: https://admin.digitalocean.dextinity.com/public-api/api
       - key: API_URL_INTERNAL
         scope: RUN_AND_BUILD_TIME
-        value: https://admin.digitalocean.comet-dxp.com/public-api/api
+        value: https://admin.digitalocean.dextinity.com/public-api/api
       - key: SITE_PREVIEW_SECRET
         scope: RUN_AND_BUILD_TIME
         type: SECRET
@@ -61,6 +61,6 @@ services:
     http_port: 3000
     instance_count: 1
     instance_size_slug: apps-s-1vcpu-0.5gb
-    name: comet-starter-site-main
+    name: dextinity-starter-site-main
     run_command: npm run serve
     source_dir: site

--- a/.github/workflows/update-digital-ocean-deployment.yml
+++ b/.github/workflows/update-digital-ocean-deployment.yml
@@ -24,11 +24,11 @@ jobs:
 
       - name: Inject Site Configurations
         run: |
-          sed -i 's/dev\.comet\-dxp\.com/digitalocean.comet-dxp.com/g' site-configs/main.ts
-          APP_ENV=dev npx -y @dextinity/cli inject-site-configs -f site-configs/site-configs.ts -i .digitalocean/comet-starter-cms.tpl.yaml -o .digitalocean/comet-starter-cms.yaml --base64
-          APP_ENV=dev npx -y @dextinity/cli inject-site-configs -f site-configs/site-configs.ts -i .digitalocean/comet-starter-site-main.tpl.yaml -o .digitalocean/comet-starter-site-main.yaml --base64
+          sed -i 's/dev\.dextinity\.com/digitalocean.dextinity.com/g' site-configs/main.ts
+          APP_ENV=dev npx -y @dextinity/cli inject-site-configs -f site-configs/site-configs.ts -i .digitalocean/dextinity-starter-cms.tpl.yaml -o .digitalocean/dextinity-starter-cms.yaml --base64
+          APP_ENV=dev npx -y @dextinity/cli inject-site-configs -f site-configs/site-configs.ts -i .digitalocean/dextinity-starter-site-main.tpl.yaml -o .digitalocean/dextinity-starter-site-main.yaml --base64
 
-      - name: Update DigitalOcean comet-starter-imgproxy Deployment
+      - name: Update DigitalOcean dextinity-starter-imgproxy Deployment
         uses: digitalocean/app_action/deploy@v2
         env:
           IMGPROXY_KEY: ${{ secrets.IMGPROXY_KEY }}
@@ -39,9 +39,9 @@ jobs:
           token: ${{ secrets.DIGITALOCEAN_API_KEY }}
           print_deploy_logs: true
           print_build_logs: true
-          app_spec_location: ".digitalocean/comet-starter-imgproxy.yaml"
+          app_spec_location: ".digitalocean/dextinity-starter-imgproxy.yaml"
 
-      - name: Update DigitalOcean comet-starter-cms Deployment
+      - name: Update DigitalOcean dextinity-starter-cms Deployment
         uses: digitalocean/app_action/deploy@v2
         env:
           POSTGRESQL_PASSWORD: ${{ secrets.POSTGRESQL_PASSWORD }}
@@ -58,9 +58,9 @@ jobs:
           token: ${{ secrets.DIGITALOCEAN_API_KEY }}
           print_deploy_logs: true
           print_build_logs: true
-          app_spec_location: ".digitalocean/comet-starter-cms.yaml"
+          app_spec_location: ".digitalocean/dextinity-starter-cms.yaml"
 
-      - name: Update DigitalOcean comet-starter-site-main Deployment
+      - name: Update DigitalOcean dextinity-starter-site-main Deployment
         uses: digitalocean/app_action/deploy@v2
         env:
           SITE_PREVIEW_SECRET: ${{ secrets.SITE_PREVIEW_SECRET }}
@@ -69,4 +69,4 @@ jobs:
           token: ${{ secrets.DIGITALOCEAN_API_KEY }}
           print_deploy_logs: true
           print_build_logs: true
-          app_spec_location: ".digitalocean/comet-starter-site-main.yaml"
+          app_spec_location: ".digitalocean/dextinity-starter-site-main.yaml"


### PR DESCRIPTION
The `sed` call in `deploy.sh` and in the workflow still looked for the old dev domain, which `site-configs/main.ts` no longer contains, so the injected configs kept `dev.dextinity.com` instead of the DigitalOcean domain.

`IMGPROXY_URL` keeps the `comet-starter-imgproxy-ovgzu.ondigitalocean.app` hostname. App Platform assigns that hostname when an app is created and keeps it when the app is renamed, so it stays valid and cannot be renamed along with everything else.

`CORS_ALLOWED_ORIGIN` now holds the site's own domain instead of the site app's generated hostname. That is the origin the site calls the API from, and it also survives recreating the app.

`BLOB_STORAGE_DIRECTORY_PREFIX` stays `starter`. The object keys stored in the database are relative to it, so renaming it would make every existing DAM file unreachable.